### PR TITLE
Disable app initialization on assets precompile

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,7 @@ module Feeder
 
     # Enable the asset pipeline
     config.assets.enabled = true
+    config.assets.initialize_on_precompile = false
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'


### PR DESCRIPTION
This change allows us to precompile assets on a hosts without a database connection. 

This is useful for generating omnibus packages to deploy. 

@teknofire Any potential issues with merging this change?